### PR TITLE
Add support for argparse

### DIFF
--- a/balchivist/archiver.py
+++ b/balchivist/archiver.py
@@ -38,7 +38,8 @@ class BALArchiver(object):
         tries = 0
         while tries < self.retries:
             try:
-                self.IAItem = internetarchive.Item(identifier, max_retries=retries)
+                self.IAItem = internetarchive.Item(identifier,
+                                                   max_retries=retries)
                 break
             except:
                 tries += 1

--- a/messages/en.json
+++ b/messages/en.json
@@ -5,5 +5,6 @@
         ]
     },
     "exception-incorrectusage": "Error: This script cannot be used directly! Please use runner.py instead.",
+    "exception-nomodules": "Error: There are no modules installed in settings.conf! Please install at least one module so that the script can do something.",
     "error-unknowntype": "Error: There are no modules that can support this unknown type."
 }

--- a/modules/dumps.py
+++ b/modules/dumps.py
@@ -67,31 +67,28 @@ class BALMDumps(object):
             'status.html'
         ]
 
-    def argparse(self, subparser=None):
+    def argparse(self, parser=None):
         """
         This function is used for declaring the valid arguments specific to
         this module and should only be used during the argparse stage.
 
-        - subparser (object): The subparser object.
+        - parser (object): The parser object.
         """
-        parser = subparser.add_parser(
-            "dumps",
-            description="Module for archiving the full Wikimedia wiki dumps."
+        group = parser.add_argument_group(
+            title="Wikimedia dumps",
+            description="The full database dumps of Wikimedia wikis."
         )
-        parser.add_argument("-j", "--job", action="store",
-                            choices=self.jobs, default="archive",
-                            help="The job to execute.")
-        parser.add_argument("-w", "--wiki", action="store",
-                            help="The wiki to work on.")
-        parser.add_argument("-d", "--date", action="store",
-                            help="The date of the wiki dump to work on.")
-        parser.add_argument("-p", "--path", action="store",
-                            help="The path to the wiki dump directory.")
-        parser.add_argument("-r", "--resume", action="store_true",
-                            default=False,
-                            help="Resume uploading a wiki dump instead of "
-                            "restarting all over.")
-        parser.set_defaults(action="dumps")
+        group.add_argument("--dumps-job", action="store", choices=self.jobs,
+                           default="archive", help="The job to execute.")
+        group.add_argument("--dumps-wiki", action="store",
+                           help="The wiki to work on.")
+        group.add_argument("--dumps-date", action="store",
+                           help="The date of the wiki dump to work on.")
+        group.add_argument("--dumps-path", action="store",
+                           help="The path to the wiki dump directory.")
+        group.add_argument("--dumps-resume", action="store_true", default=False,
+                           help="Resume uploading a wiki dump instead of "
+                           "restarting all over.")
 
     def getDumpProgress(self, subject, date):
         """

--- a/modules/dumps.py
+++ b/modules/dumps.py
@@ -88,9 +88,10 @@ class BALMDumps(object):
                            help="The date of the wiki dump to work on.")
         group.add_argument("--dumps-path", action="store", dest="dumpspath",
                            help="The path to the wiki dump directory.")
-        group.add_argument("--dumps-resume", action="store_true", default=False,
-                           dest="dumpsresume", help="Resume uploading a wiki "
-                           "dump instead of restarting all over.")
+        group.add_argument("--dumps-resume", action="store_true",
+                           default=False, dest="dumpsresume",
+                           help="Resume uploading a wiki dump instead of "
+                           "restarting all over.")
 
     def getDumpProgress(self, subject, date):
         """
@@ -588,14 +589,14 @@ class BALMDumps(object):
         error has occurred.
         """
         continuous = False
-        if (args is None) or (args.dumpswiki is None and args.dumpsdate is None):
+        if args is None or (args.dumpswiki is None and args.dumpsdate is None):
             # It is likely that --auto has been declared when args is None
             continuous = True
         elif (args.dumpswiki is None and args.dumpsdate is not None):
-            self.common.giveError("Error: Dump date was given but not the wiki")
+            self.common.giveError("Error: Date was given but not the wiki!")
             return False
         elif (args.dumpswiki is not None and args.dumpsdate is None):
-            self.common.giveError("Error: Wiki was given but not the dump date")
+            self.common.giveError("Error: Wiki was given but not the date!")
             return False
         elif (args.dumpsjob == "update"):
             return self.update()
@@ -619,8 +620,8 @@ class BALMDumps(object):
                               path=dumpspath)
         else:
             self.resume = args.dumpsresume
-            self.dispatch(job=args.dumpsjob, subject=subject, date=date,
-                          path=args.dumpspath)
+            self.dispatch(job=args.dumpsjob, subject=args.dumpswiki,
+                          date=args.dumpsdate, path=args.dumpspath)
 
         return True
 

--- a/modules/dumps.py
+++ b/modules/dumps.py
@@ -79,7 +79,7 @@ class BALMDumps(object):
             description="Module for archiving the full Wikimedia wiki dumps."
         )
         parser.add_argument("-j", "--job", action="store",
-                            choices=self.jobs, default="archive"
+                            choices=self.jobs, default="archive",
                             help="The job to execute.")
         parser.add_argument("-w", "--wiki", action="store",
                             help="The wiki to work on.")

--- a/runner.py
+++ b/runner.py
@@ -86,14 +86,14 @@ class BALRunner(object):
                    "https://github.com/Hydriz/Balchivist",
             formatter_class=argparse.ArgumentDefaultsHelpFormatter
         )
+        parser.add_argument("-V", "--version", action="version",
+                            version="Balchivist Python Library %s" % (version))
 
         # Argument group for general options
         generalopts = parser.add_argument_group(
             title="General options",
             description="Generic options when executing the runner."
         )
-        generalopts.add_argument("-V", "--version", action="version",
-                                 version="Balchivist Python Library %s" % (version))
         generalopts.add_argument("-D", "--debug", action="store_true",
                                  default=False,
                                  help="Don't modify anything, but output the "

--- a/runner.py
+++ b/runner.py
@@ -35,7 +35,6 @@ class BALRunner(object):
                                          default=config.get('defaults_file'))
         self.modules = json.loads(config.get('modules'))
         self.message = balchivist.BALMessage()
-        self.common = balchivist.BALCommon()
         # The database table hosting the information on dumps
         self.dbtable = "archive"
 
@@ -112,6 +111,7 @@ class BALRunner(object):
 
         # Let's parse the arguments given by the user now
         args = parser.parse_args()
+        common = balchivist.BALCommon(verbose=args.verbose, debug=args.debug)
 
         params = {
             "verbose": args.verbose,
@@ -123,6 +123,7 @@ class BALRunner(object):
                 ClassModule = getattr(modules, classtype)(params=params,
                                                           sqldb=self.sqldb)
                 ClassModule.execute(args=args)
+                break
             else:
                 for module in self.modules:
                     classtype = "BALM" + module.title()
@@ -137,7 +138,7 @@ class BALRunner(object):
 
             # Determine if we should exit the script now
             if (args.debug):
-                self.common.giveMessage("Nothing to be done!")
+                common.giveMessage("Nothing to be done!")
                 break
             elif (args.crontab):
                 # Crontab mode is active, exit when everything is done
@@ -145,7 +146,7 @@ class BALRunner(object):
             else:
                 # Allow the script to sleep for 6 hours
                 timenow = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
-                self.common.giveMessage("Sleeping for 6 hours, %s" % (timenow))
+                common.giveMessage("Sleeping for 6 hours, %s" % (timenow))
                 time.sleep(60*60*6)
 
 


### PR DESCRIPTION
`argparse` is supposedly a better option for parsing arguments as it allows for different types of options depending on the module being loaded.

Current pending issues:
- [x] Unable to run the script without declaring the dataset type to work on. Breaks the continuous daemon.
- [x] E.g. `--verbose` can be used provided it appears before the dataset type to work on. Declaring it last causes an "unknown argument" error.
